### PR TITLE
feat: API DTO 스키마 v2 업데이트

### DIFF
--- a/libs/dto/src/auth/Auth2FASetupResponse.ts
+++ b/libs/dto/src/auth/Auth2FASetupResponse.ts
@@ -1,0 +1,7 @@
+import { Type, Static } from '@sinclair/typebox';
+
+export const Auth2FASetupResponseSchema = Type.Object({
+  qrLink: Type.String(),
+  secretKey: Type.String(),
+});
+export type Auth2FASetupResponseDTO = Static<typeof Auth2FASetupResponseSchema>;

--- a/libs/dto/src/auth/Auth2FAVerifyRequest.ts
+++ b/libs/dto/src/auth/Auth2FAVerifyRequest.ts
@@ -1,0 +1,6 @@
+import { Type, Static } from '@sinclair/typebox';
+
+export const Auth2FAVerifyRequestSchema = Type.Object({
+  token: Type.String(),
+});
+export type Auth2FAVerifyRequestDTO = Static<typeof Auth2FAVerifyRequestSchema>;

--- a/libs/dto/src/auth/AuthSetupResponse.ts
+++ b/libs/dto/src/auth/AuthSetupResponse.ts
@@ -1,6 +1,0 @@
-import { Type, Static } from '@sinclair/typebox';
-
-export const AuthSetupResponseSchema = Type.Object({
-  qrLink: Type.String(),
-});
-export type AuthSetupResponseDTO = Static<typeof AuthSetupResponseSchema>;

--- a/libs/dto/src/auth/AuthVerifyRequest.ts
+++ b/libs/dto/src/auth/AuthVerifyRequest.ts
@@ -1,6 +1,0 @@
-import { Type, Static } from '@sinclair/typebox';
-
-export const AuthVerifyRequestSchema = Type.Object({
-  token: Type.String(),
-});
-export type AuthVerifyRequestDTO = Static<typeof AuthVerifyRequestSchema>;

--- a/libs/dto/src/auth/AuthVerifyResponse.ts
+++ b/libs/dto/src/auth/AuthVerifyResponse.ts
@@ -1,7 +1,0 @@
-import { Type, Static } from '@sinclair/typebox';
-
-export const AuthVerifyResponseSchema = Type.Object({
-  success: Type.Boolean(),
-  error: Type.Union([Type.String(), Type.Null()]),
-});
-export type AuthVerifyResponseDTO = Static<typeof AuthVerifyResponseSchema>;

--- a/libs/dto/src/auth/index.ts
+++ b/libs/dto/src/auth/index.ts
@@ -1,3 +1,2 @@
-export * from './AuthVerifyRequest.js';
-export * from './AuthVerifyResponse.js';
-export * from './AuthSetupResponse.js';
+export * from './Auth2FAVerifyRequest.js';
+export * from './Auth2FASetupResponse.js';

--- a/libs/dto/src/token/TwoFactorPayload.ts
+++ b/libs/dto/src/token/TwoFactorPayload.ts
@@ -2,11 +2,3 @@ export interface TwoFactorSecret {
   base32: string;
   otpauth_url: string;
 }
-
-export interface SecretResponse {
-  secret: string;
-}
-
-export interface TwoFAResponse {
-  twoFA: boolean;
-}

--- a/libs/dto/src/tournament/GameResponse.ts
+++ b/libs/dto/src/tournament/GameResponse.ts
@@ -1,11 +1,12 @@
-import { Type as TypeBox, Static as StaticBox } from '@sinclair/typebox';
+import { Type, Static } from '@sinclair/typebox';
 
-export const GameResponseSchema = TypeBox.Object({
-  round: TypeBox.Number(),
-  player1: TypeBox.String(),
-  player2: TypeBox.String(),
-  winnerId: TypeBox.Union([TypeBox.Literal(1), TypeBox.Literal(2), TypeBox.Null()]),
-  player1Score: TypeBox.Union([TypeBox.Number(), TypeBox.Null()]),
-  player2Score: TypeBox.Union([TypeBox.Number(), TypeBox.Null()]),
+export const GameResponseSchema = Type.Object({
+  gameId: Type.Number(),
+  round: Type.Number(),
+  player1: Type.String(),
+  player2: Type.String(),
+  winnerId: Type.Union([Type.Literal(1), Type.Literal(2), Type.Null()]),
+  player1Score: Type.Union([Type.Number(), Type.Null()]),
+  player2Score: Type.Union([Type.Number(), Type.Null()]),
 });
-export type GameResponseDTO = StaticBox<typeof GameResponseSchema>;
+export type GameResponseDTO = Static<typeof GameResponseSchema>;

--- a/libs/dto/src/tournament/GameUpdateRequest.ts
+++ b/libs/dto/src/tournament/GameUpdateRequest.ts
@@ -1,6 +1,7 @@
 import { Type, Static } from '@sinclair/typebox';
 
 export const GameUpdateRequestSchema = Type.Object({
+  gameID: Type.Number(),
   player1: Type.String(),
   player2: Type.String(),
   player1Score: Type.Number(),

--- a/libs/dto/src/tournament/GameUpdateResponse.ts
+++ b/libs/dto/src/tournament/GameUpdateResponse.ts
@@ -1,8 +1,6 @@
 import { Type, Static } from '@sinclair/typebox';
 
 export const GameUpdateResponseSchema = Type.Object({
-  gameId: Type.String({ format: 'uuid' }),
-  round: Type.Number(),
-  winnerId: Type.Union([Type.Literal(1), Type.Literal(2), Type.Null()]),
+  gameId: Type.Number(),
 });
 export type GameUpdateResponseDTO = Static<typeof GameUpdateResponseSchema>;

--- a/libs/dto/src/tournament/TournamentCreateRequest.ts
+++ b/libs/dto/src/tournament/TournamentCreateRequest.ts
@@ -1,8 +1,8 @@
 import { Type, Static } from '@sinclair/typebox';
 
 export const TournamentCreateRequestSchema = Type.Object({
-  playerCount: Type.Number(),
+  playerCount: Type.Union([Type.Literal(2), Type.Literal(4), Type.Literal(8)]),
+  targetScore: Type.Union([Type.Literal(1), Type.Literal(3), Type.Literal(5)]),
   playerList: Type.Array(Type.String()),
-  targetScore: Type.Number(),
 });
 export type TournamentCreateRequestDTO = Static<typeof TournamentCreateRequestSchema>;

--- a/libs/dto/src/tournament/TournamentCreateResponse.ts
+++ b/libs/dto/src/tournament/TournamentCreateResponse.ts
@@ -1,6 +1,6 @@
 import { Type, Static } from '@sinclair/typebox';
 
 export const TournamentCreateResponseSchema = Type.Object({
-  tournamentId: Type.String({ format: 'uuid' }),
+  tournamentId: Type.Number(),
 });
 export type TournamentCreateResponseDTO = Static<typeof TournamentCreateResponseSchema>;

--- a/libs/dto/src/tournament/TournamentInfoResponse.ts
+++ b/libs/dto/src/tournament/TournamentInfoResponse.ts
@@ -2,8 +2,8 @@ import { Type, Static } from '@sinclair/typebox';
 import { GameResponseSchema } from './GameResponse.js';
 
 export const TournamentInfoResponseSchema = Type.Object({
-  playerCount: Type.Number(),
-  targetScore: Type.Number(),
+  playerCount: Type.Union([Type.Literal(2), Type.Literal(4), Type.Literal(8)]),
+  targetScore: Type.Union([Type.Literal(1), Type.Literal(3), Type.Literal(5)]),
   isFinished: Type.Boolean(),
   games: Type.Array(GameResponseSchema),
 });

--- a/libs/dto/src/tournament/TournamentListResponse.ts
+++ b/libs/dto/src/tournament/TournamentListResponse.ts
@@ -1,7 +1,7 @@
 import { Type, Static } from '@sinclair/typebox';
 
 const TournamentItemSchema = Type.Object({
-  tournamentId: Type.String({ format: 'uuid' }),
+  tournamentId: Type.Number(),
   isFinished: Type.Boolean(),
   createdAt: Type.String({ format: 'date-time' }),
 });

--- a/libs/dto/src/user/UserSecretKeyResponse.ts
+++ b/libs/dto/src/user/UserSecretKeyResponse.ts
@@ -1,0 +1,6 @@
+import { Type, Static } from '@sinclair/typebox';
+
+export const UserSecretKeyResponseSchema = Type.Object({
+  secretKey: Type.String(),
+});
+export type UserSecretKeyResponseDTO = Static<typeof UserSecretKeyResponseSchema>;

--- a/libs/dto/src/user/UserSettingUpdateResponse.ts
+++ b/libs/dto/src/user/UserSettingUpdateResponse.ts
@@ -1,0 +1,7 @@
+import { Type, Static } from '@sinclair/typebox';
+
+export const UserSettingUpdateResponseSchema = Type.Object({
+  twofa: Type.Boolean(),
+  qrLink: Type.String(),
+});
+export type UserSettingUpdateResponseDTO = Static<typeof UserSettingUpdateResponseSchema>;

--- a/libs/dto/src/user/index.ts
+++ b/libs/dto/src/user/index.ts
@@ -1,2 +1,4 @@
 export * from './UserSettingResponse.js';
 export * from './UserSettingUpdateRequest.js';
+export * from './UserSettingUpdateResponse.js';
+export * from './UserSecretKeyResponse.js';


### PR DESCRIPTION
## 목적
서버와 클라이언트 사이의 api dto 추가 및 변동 사항을 업데이트 합니다.

## 작업 항목
- TournamentDTO에 gameID 추가 및 targetScore, playerCount Literal 설정
- SecretKey 관련 DTO 추가

