### PR TITLE
feat: Tournament controller service repository 레이어 구현 완료

### DIFF
--- a/apps/main-server/src/repository/game.repository.ts
+++ b/apps/main-server/src/repository/game.repository.ts
@@ -1,40 +1,101 @@
 import { Knex } from 'knex';
 import { Game } from '../entity/game.entity.js';
-import { GameUpdateRequestDTO } from '@hst/dto';
 
 export class GameRepository {
   constructor(private db: Knex) {}
 
-  async create(tournamentId: number, dto: GameUpdateRequestDTO): Promise<Game> {
+  private mapToEntity(game: any): Game {
+    return {
+      id: game.id,
+      tournamentId: game.tournament_id,
+      round: game.round,
+      player1: game.player1,
+      player2: game.player2,
+      player1Score: game.player1_score,
+      player2Score: game.player2_score,
+      createdAt: game.created_at,
+      modifiedAt: game.modified_at,
+    };
+  }
+
+  async create(
+    tournamentId: number,
+    round: number,
+    player1: string,
+    player2: string,
+    player1Score: number = 0,
+    player2Score: number = 0,
+  ): Promise<Game> {
     const [game] = await this.db('game')
       .insert({
         tournament_id: tournamentId,
-        player1: dto.player1,
-        player2: dto.player2,
-        player1Score: 0,
-        player2Score: 0,
+        round,
+        player1,
+        player2,
+        player1_score: player1Score,
+        player2_score: player2Score,
         created_at: this.db.fn.now(),
-        modified_at: this.db.fn.now()
+        modified_at: this.db.fn.now(),
       })
       .returning('*');
-    
-    return game;
+
+    return this.mapToEntity(game);
+  }
+
+  async updateScore(
+    id: number,
+    player1Score: number,
+    player2Score: number,
+  ): Promise<Game | undefined> {
+    const [game] = await this.db('game')
+      .where('id', id)
+      .update({
+        player1_score: player1Score,
+        player2_score: player2Score,
+        modified_at: this.db.fn.now(),
+      })
+      .returning('*');
+
+    return game ? this.mapToEntity(game) : undefined;
+  }
+
+  async updatePlayer(
+    id: number,
+    playerPosition: number,
+    winner: string | null,
+  ): Promise<Game | undefined> {
+    const playerField = `player${playerPosition}`;
+
+    const [game] = await this.db('game')
+      .where('id', id)
+      .update({
+        [playerField]: winner,
+        modified_at: this.db.fn.now(),
+      })
+      .returning('*');
+
+    return game ? this.mapToEntity(game) : undefined;
   }
 
   async findById(id: number): Promise<Game | undefined> {
-    return await this.db('game').where('id', id).first();
+    const game = await this.db('game').where('id', id).first();
+    return game ? this.mapToEntity(game) : undefined;
   }
 
-  async findByTournamentId(tournamentId: number): Promise<Game[]> {
-    return await this.db('game')
+  async findAllByTournamentId(tournamentId: number): Promise<Game[]> {
+    const games = await this.db('game')
       .where('tournament_id', tournamentId)
       .orderBy('created_at', 'asc');
+
+    return games.map((game) => this.mapToEntity(game));
   }
 
-  async findByPlayer(player: string): Promise<Game[]> {
-    return await this.db('game')
-      .where('player1', player)
-      .orWhere('player2', player)
-      .orderBy('created_at', 'desc');
+  async findByTournamentIdAndRound(tournamentId: number, round: number): Promise<Game | undefined> {
+    const game = await this.db('game')
+      .where('tournament_id', tournamentId)
+      .where('round', round)
+      .first();
+
+    return game ? this.mapToEntity(game) : undefined;
   }
 }

--- a/apps/main-server/src/repository/tournament.repository.ts
+++ b/apps/main-server/src/repository/tournament.repository.ts
@@ -1,33 +1,55 @@
 import { Knex } from 'knex';
 import { Tournament } from '../entity/tournament.entity.js';
-import { TournamentCreateRequestDTO } from '@hst/dto';
 
 export class TournamentRepository {
   constructor(private db: Knex) {}
 
-  async create(userId: number, dto: TournamentCreateRequestDTO): Promise<Tournament> {
+  private mapToEntity(tournament: any): Tournament {
+    return {
+      id: tournament.id,
+      userId: tournament.user_id,
+      playerCount: tournament.player_count,
+      targetScore: tournament.target_score,
+      isFinished: !!tournament.is_finished,
+      createdAt: tournament.created_at,
+      modifiedAt: tournament.modified_at,
+    };
+  }
+
+  async create(userId: number, playerCount: number, targetScore: number): Promise<Tournament> {
     const [tournament] = await this.db('tournament')
       .insert({
         user_id: userId,
-        player_count: dto.playerCount,
-        target_score: dto.targetScore,
+        player_count: playerCount,
+        target_score: targetScore,
         is_finished: false,
         created_at: this.db.fn.now(),
-        modified_at: this.db.fn.now()
+        modified_at: this.db.fn.now(),
       })
       .returning('*');
-    
-    return tournament;
+
+    return this.mapToEntity(tournament);
+  }
+
+  async updateFinished(id: number, isFinished: boolean): Promise<Tournament | undefined> {
+    const [tournament] = await this.db('tournament')
+      .where('id', id)
+      .update({
+        is_finished: isFinished,
+        modified_at: this.db.fn.now(),
+      })
+      .returning('*');
+
+    return tournament ? this.mapToEntity(tournament) : undefined;
   }
 
   async findById(id: number): Promise<Tournament | undefined> {
-    return await this.db('tournament').where('id', id).first();
+    const tournament = await this.db('tournament').where('id', id).first();
+    return tournament ? this.mapToEntity(tournament) : undefined;
   }
 
   async findAllByUserId(userId: number): Promise<Tournament[]> {
-    return await this.db('tournament')
-      .where('user_id', userId)
-      .orderBy('created_at', 'desc');
+    const tournaments = await this.db('tournament').where('user_id', userId);
+    return tournaments.map((tournament) => this.mapToEntity(tournament));
   }
-
 }

--- a/apps/main-server/src/routes/api/tournament.controller.ts
+++ b/apps/main-server/src/routes/api/tournament.controller.ts
@@ -1,4 +1,3 @@
-import { FastifyInstance } from 'fastify';
 import { GameService } from '../../service/game.service.js';
 import { TournamentService } from '../../service/tournament.service.js';
 import {
@@ -8,6 +7,8 @@ import {
   TournamentListResponseSchema,
   TournamentInfoResponseSchema,
   GameUpdateRequestSchema,
+  ErrorResponseSchema,
+  GameUpdateResponseSchema,
 } from '@hst/dto';
 import { FastifyPluginAsyncTypebox, Type } from '@fastify/type-provider-typebox';
 
@@ -67,16 +68,25 @@ const plugin: FastifyPluginAsyncTypebox = async (app) => {
     '/tournaments/:tournamentId',
     {
       schema: {
+        params: Type.Object({
+          tournamentId: Type.String({ pattern: '^[0-9]+$' }),
+        }),
         response: {
           200: TournamentInfoResponseSchema,
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
         },
+        tags: ['tournaments'],
       },
     },
     async (request, reply) => {
       const { email } = request.user;
       try {
-        const tournamentId = parseInt(request.params.id);
-        const tournament = await gameService.findByGamesByTournamentId(tournamentId);
+        const tournamentId = parseInt(request.params.tournamentId);
+        if (isNaN(tournamentId)) {
+          return reply.status(400).send({ error: 'Invalid tournament ID' });
+        }
 
         const tournament = await gameService.getGamesByTournamentId(email, tournamentId);
         if (!tournament) {
@@ -85,7 +95,6 @@ const plugin: FastifyPluginAsyncTypebox = async (app) => {
 
         return reply.send(tournament);
       } catch (error) {
-        app.log.error('Error getting tournament:', error);
         return reply.status(500).send({ error: 'Failed to get tournament' });
       }
     },
@@ -95,17 +104,17 @@ const plugin: FastifyPluginAsyncTypebox = async (app) => {
     '/tournaments/:tournamentId/games',
     {
       schema: {
-        params: {
-          type: 'object',
-          properties: {
-            tournamentId: { type: 'string', pattern: '^[0-9]+$' },
-          },
-          required: ['tournamentId'],
-        },
+        params: Type.Object({
+          tournamentId: Type.String({ pattern: '^[0-9]+$' }),
+        }),
         body: GameUpdateRequestSchema,
         response: {
-          204: 'NULL',
+          200: GameUpdateResponseSchema,
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          500: ErrorResponseSchema,
         },
+        tags: ['tournaments'],
       },
     },
     async (request, reply) => {
@@ -117,14 +126,17 @@ const plugin: FastifyPluginAsyncTypebox = async (app) => {
         }
         const gameData = request.body;
 
-        const tournament = await tournamentService.findById(tournamentId);
-        const updatedGame = await gameService.createGame(tournamentId, gameData);
+        const updatedGame = await gameService.updateGame(email, tournamentId, gameData);
+        if (!updatedGame) {
+          return reply.status(404).send({ error: 'Tournament not found' });
+        }
 
-        return reply.status(204).send();
+        return reply.status(200).send(updatedGame);
       } catch (error) {
-        app.log.error('Error updating game scores:', error);
         return reply.status(500).send({ error: 'Failed to update game scores' });
       }
     },
   );
-}
+};
+
+export default plugin;

--- a/apps/main-server/src/service/game.service.ts
+++ b/apps/main-server/src/service/game.service.ts
@@ -3,6 +3,7 @@ import { TournamentRepository } from '../repository/tournament.repository.js';
 import { UserRepository } from '../repository/user.repository.js';
 import { DatabaseConfig } from '../config/database.config.js';
 import { GameUpdateRequestDTO } from '@hst/dto';
+import { FastifyInstance } from 'fastify';
 
 export class GameService {
   private gameRepo: GameRepository;
@@ -14,6 +15,10 @@ export class GameService {
     this.gameRepo = new GameRepository(db);
     this.tournamentRepo = new TournamentRepository(db);
     this.userRepo = new UserRepository(db);
+  constructor(app: FastifyInstance) {
+    this.gameRepo = new GameRepository(app.knex);
+    this.tournamentRepo = new TournamentRepository(app.knex);
+    this.userRepo = new UserRepository(app.knex);
   }
 
   async findByGamesByTournamentId(tournamentId: number): Promise<any | null> {

--- a/apps/main-server/src/service/game.service.ts
+++ b/apps/main-server/src/service/game.service.ts
@@ -1,8 +1,9 @@
 import { GameRepository } from '../repository/game.repository.js';
 import { TournamentRepository } from '../repository/tournament.repository.js';
 import { UserRepository } from '../repository/user.repository.js';
-import { DatabaseConfig } from '../config/database.config.js';
-import { GameUpdateRequestDTO } from '@hst/dto';
+import { Tournament } from '../entity/tournament.entity.js';
+import { GameUpdateRequestDTO, GameUpdateResponseDTO, TournamentInfoResponseDTO } from '@hst/dto';
+
 import { FastifyInstance } from 'fastify';
 
 export class GameService {
@@ -10,34 +11,165 @@ export class GameService {
   private tournamentRepo: TournamentRepository;
   private userRepo: UserRepository;
 
-  constructor() {
-    const db = DatabaseConfig.getInstance();
-    this.gameRepo = new GameRepository(db);
-    this.tournamentRepo = new TournamentRepository(db);
-    this.userRepo = new UserRepository(db);
   constructor(app: FastifyInstance) {
     this.gameRepo = new GameRepository(app.knex);
     this.tournamentRepo = new TournamentRepository(app.knex);
     this.userRepo = new UserRepository(app.knex);
   }
 
-  async findByGamesByTournamentId(tournamentId: number): Promise<any | null> {
-    const tournament = await this.tournamentRepo.findById(tournamentId);
-    if (!tournament) return null;
+  async getGamesByTournamentId(
+    userEmail: string,
+    tournamentId: number,
+  ): Promise<TournamentInfoResponseDTO | null> {
+    const { tournament } = await this.validateUserAndTournament(userEmail, tournamentId);
 
-    const games = await this.gameRepo.findByTournamentId(tournamentId);
+    const games = await this.gameRepo.findAllByTournamentId(tournamentId);
+
+    const gameResponseDTOs = games.map((game) => ({
+      gameId: game.id,
+      round: game.round,
+      player1: game.player1,
+      player2: game.player2,
+      winnerId: this.determineWinner(game.player1Score, game.player2Score, tournament.targetScore),
+      player1Score: game.player1Score,
+      player2Score: game.player2Score,
+    }));
 
     return {
-      ...tournament,
-      games,
+      playerCount: tournament.playerCount as 2 | 4 | 8,
+      targetScore: tournament.targetScore as 1 | 3 | 5,
+      isFinished: tournament.isFinished,
+      games: gameResponseDTOs,
     };
   }
 
-  async createGame(tournamentId: number, dto: GameUpdateRequestDTO): Promise<any> {
-    const tournament = await this.tournamentRepo.findById(tournamentId);
-    if (!tournament) throw new Error('Tournament not found');
+  async updateGame(
+    userEmail: string,
+    tournamentId: number,
+    dto: GameUpdateRequestDTO,
+  ): Promise<GameUpdateResponseDTO> {
+    const { tournament } = await this.validateUserAndTournament(userEmail, tournamentId);
 
-    const game = await this.gameRepo.create(tournamentId, dto);
+    await this.validateGameUpdate(tournament, dto, tournamentId);
+
+    const updatedGame = await this.gameRepo.updateScore(
+      dto.gameID,
+      dto.player1Score,
+      dto.player2Score,
+    );
+    if (!updatedGame) {
+      throw new Error('Failed to update game score');
+    }
+    const game = await this.gameRepo.findById(dto.gameID);
+    if (!game) {
+      throw new Error('Game not found');
+    }
+
+    const winnerId = this.determineWinner(
+      dto.player1Score,
+      dto.player2Score,
+      tournament.targetScore,
+    );
+    if (winnerId) {
+      const winner = winnerId === 1 ? game!.player1 : game!.player2;
+      await this.advanceToNextRound(tournamentId, game!.round, winner, dto);
+    } else {
+      throw new Error('No winner determined from the scores');
+    }
+
+    return {
+      gameId: dto.gameID,
+    };
+  }
+
+  private async advanceToNextRound(
+    tournamentId: number,
+    currentRound: number,
+    winner: string,
+    dto: GameUpdateRequestDTO,
+  ): Promise<void> {
+    const nextRound = Math.floor(currentRound / 2);
+    if (nextRound === 0) {
+      await this.tournamentRepo.updateFinished(tournamentId, true);
+      return;
+    }
+
+    const nextRoundGame = await this.gameRepo.findByTournamentIdAndRound(tournamentId, nextRound);
+    if (!nextRoundGame) throw new Error('Next round game not found');
+    if (nextRoundGame.player1 && nextRoundGame.player2) {
+      throw new Error('Next round game already has both players');
+    }
+
+    const playerPosition = currentRound % 2 === 1 ? 1 : 2;
+    const previousGame = await this.gameRepo.findById(currentRound * 2);
+    const previousGame2 = await this.gameRepo.findById(currentRound * 2 + 1);
+
+    if (previousGame && previousGame2) {
+      if (previousGame.player1 === winner || previousGame2.player1 === winner) {
+        throw new Error('Winner already exists in next round game');
+      }
+    }
+
+    await this.gameRepo.updatePlayer(nextRoundGame.id, playerPosition, winner);
+  }
+
+  private determineWinner(
+    player1Score: number,
+    player2Score: number,
+    targetScore: number,
+  ): 1 | 2 | null {
+    if (player1Score > player2Score && player1Score === targetScore) return 1;
+    if (player2Score > player1Score && player2Score === targetScore) return 2;
+    return null;
+  }
+
+  private async validateUserAndTournament(userEmail: string, tournamentId: number) {
+    const user = await this.userRepo.findByEmail(userEmail);
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const tournament = await this.tournamentRepo.findById(tournamentId);
+    if (!tournament) {
+      throw new Error('Tournament not found');
+    }
+
+    if (tournament.userId !== user.id) {
+      throw new Error('Access denied: You are not the owner of this tournament');
+    }
+
+    return { tournament };
+  }
+
+  private async validateGameUpdate(
+    tournament: Tournament,
+    dto: GameUpdateRequestDTO,
+    tournamentId: number,
+  ) {
+    if (tournament.isFinished) {
+      throw new Error('Tournament is already finished');
+    }
+
+    const game = await this.gameRepo.findById(dto.gameID);
+    if (!game) {
+      throw new Error('Game not found');
+    }
+
+    if (game.tournamentId !== tournamentId) {
+      throw new Error('Game does not belong to this tournament');
+    }
+
+    if (
+      dto.player1Score < 0 ||
+      dto.player2Score < 0 ||
+      !Number.isInteger(dto.player1Score) ||
+      !Number.isInteger(dto.player2Score) ||
+      dto.player1Score > tournament.targetScore ||
+      dto.player2Score > tournament.targetScore
+    ) {
+      throw new Error('Scores must be non-negative');
+    }
+
     return game;
   }
 }

--- a/apps/main-server/src/service/tournament.service.ts
+++ b/apps/main-server/src/service/tournament.service.ts
@@ -1,36 +1,81 @@
 import { TournamentRepository } from '../repository/tournament.repository.js';
 import { GameRepository } from '../repository/game.repository.js';
 import { UserRepository } from '../repository/user.repository.js';
-import { DatabaseConfig } from '../config/database.config.js';
-import { TournamentCreateRequestDTO, TournamentCreateResponseDTO } from '@hst/dto';
-import { Tournament } from 'src/entity/tournament.entity.js';
+import {
+  TournamentCreateRequestDTO,
+  TournamentCreateResponseDTO,
+  TournamentListResponseDTO,
+} from '@hst/dto';
+import { FastifyInstance } from 'fastify';
 
 export class TournamentService {
   private tournamentRepo: TournamentRepository;
   private gameRepo: GameRepository;
   private userRepo: UserRepository;
 
-  constructor() {
-    const db = DatabaseConfig.getInstance();
-    this.tournamentRepo = new TournamentRepository(db);
-    this.gameRepo = new GameRepository(db);
-    this.userRepo = new UserRepository(db);
+  constructor(app: FastifyInstance) {
+    this.tournamentRepo = new TournamentRepository(app.knex);
+    this.gameRepo = new GameRepository(app.knex);
+    this.userRepo = new UserRepository(app.knex);
   }
 
-  async createTournament(
-    userId: number,
+  async initializeTournament(
+    email: string,
     dto: TournamentCreateRequestDTO,
   ): Promise<TournamentCreateResponseDTO> {
-    try {
-      const tournament = await this.tournamentRepo.create(userId, dto);
-
-      return {
-        tournamentId: tournament.id,
-      };
-    } catch (error) {
-      console.error('Error creating tournament:', error);
-      throw new Error('Failed to create tournament');
+    const user = await this.userRepo.findByEmail(email);
+    if (!user) {
+      throw new Error('User not found');
     }
+    // 플레이어 중복 체크
+    const uniquePlayers = new Set(dto.playerList);
+    if (uniquePlayers.size !== dto.playerList.length) {
+      throw new Error('Duplicate players found in player list');
+    }
+    // 플레이어 수 검증
+    if (dto.playerList.length !== dto.playerCount) {
+      throw new Error('Player list count does not match player count');
+    }
+    // 플레이어 수가 2, 4, 8 중 하나인지 확인
+    const allowedPlayerCounts = [2, 4, 8];
+    if (!allowedPlayerCounts.includes(dto.playerCount)) {
+      throw new Error('Player count must be a power: 2, 4, 8');
+    }
+    // 목표 점수가 1, 3, 5 중 하나인지 확인
+    const allowedTargetScores = [1, 3, 5];
+    if (!allowedTargetScores.includes(dto.targetScore)) {
+      throw new Error('Target score must be one of the following: 1, 3, 5');
+    }
+
+    const tournament = await this.tournamentRepo.create(user.id, dto.playerCount, dto.targetScore);
+    const rounds = tournament.playerCount - 1;
+    const initialRounds = tournament.playerCount / 2;
+
+    // 플레이어 리스트를 무작위로 섞기
+    const shuffledPlayers = [...dto.playerList].sort(() => Math.random() - 0.5);
+
+    // 초기 라운드 게임 생성
+    for (let i = rounds; i > 0; i--) {
+      let player1: string | null;
+      let player2: string | null;
+
+      if (i >= initialRounds) {
+        // 1라운드 게임들 (실제 플레이어 배치)
+        const gameIndex = i - initialRounds;
+        player1 = shuffledPlayers[gameIndex * 2];
+        player2 = shuffledPlayers[gameIndex * 2 + 1];
+      } else {
+        // 상위 라운드 게임들
+        player1 = null;
+        player2 = null;
+      }
+      // round 파라미터: 토너먼트에서의 라운드 번호
+      await this.gameRepo.create(tournament.id, i, player1, player2, 0, 0);
+    }
+
+    return {
+      tournamentId: tournament.id,
+    };
   }
 
   async findAllByUserId(userId: number): Promise<Tournament[]> {


### PR DESCRIPTION
## 주요 작업 내용
- DB 플러그인 등록
- Tournament 로직에서 Cookie에서 User의 Email 받아오게 작성
- 대진표 완전 이진트리로 작성
- 목표점수와 참가자 수 고정값으로 변경
-  각 비즈니스 로직에 예외처리 작성

## 관련 이슈
- closed #27 